### PR TITLE
Pay with paper wallet via camera and NFC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+* TBD:
+  * Pay by scanning a paper wallet (using camera or NFC)
 * v1.3.0:
   * Segwit support (native and backwards compatible addresses)
   * Hide testnet payment methods by default

--- a/css/header.css
+++ b/css/header.css
@@ -125,3 +125,11 @@ body.view-getting-started .header-button.language {
 	*/
 	display: block;
 }
+.header-button.qrcode {
+	display: none;
+	float: right;
+	background-image: url('../images/qrcode.svg');
+}
+.header-button.qrcode.visible {
+	display: block;
+}

--- a/grunt/browserify.js
+++ b/grunt/browserify.js
@@ -22,6 +22,14 @@ module.exports = {
 		src: 'node_modules/bigi/lib/index.js',
 		dest: 'build/bigi.js'
 	},
+	bitcoin: {
+		options: {
+			standalone: 'bitcoin',
+			transform: [['babelify', { presets: ['es2015'] }]]
+		},
+		src: 'node_modules/bitcoinjs-lib/src/index.js',
+		dest: 'build/bitcoin.js'
+	},
 	bs58: {
 		options: {
 			standalone: 'bs58'

--- a/grunt/concat.js
+++ b/grunt/concat.js
@@ -48,6 +48,7 @@ module.exports = {
 		nonull: true,
 		src: [
 			// Dependencies:
+			'node_modules/core-js/client/shim.js',
 			'node_modules/async/dist/async.js',
 			'node_modules/bignumber.js/bignumber.js',
 			'node_modules/jquery/dist/jquery.js',
@@ -60,6 +61,7 @@ module.exports = {
 			'build/base-x.js',
 			'build/bech32.js',
 			'build/bigi.js',
+			'build/bitcoin.js',
 			'build/bs58.js',
 			'build/buffer.js',
 			'build/ecurve.js',
@@ -77,6 +79,7 @@ module.exports = {
 			'js/util.js',
 			'js/device.js',
 			'js/screen-saver.js',
+			'js/nfc.js',
 			'js/sqlite.js',
 			'js/lang/*.js',
 			'js/abstracts/*.js',
@@ -104,6 +107,7 @@ module.exports = {
 		nonull: true,
 		src: [
 			// Dependencies:
+			'node_modules/core-js/client/shim.min.js',
 			'node_modules/async/dist/async.min.js',
 			'node_modules/bignumber.js/bignumber.min.js',
 			'node_modules/jquery/dist/jquery.min.js',
@@ -116,6 +120,7 @@ module.exports = {
 			'build/base-x.min.js',
 			'build/bech32.min.js',
 			'build/bigi.min.js',
+			'build/bitcoin.min.js',
 			'build/bs58.min.js',
 			'build/buffer.min.js',
 			'build/ecurve.min.js',
@@ -133,6 +138,7 @@ module.exports = {
 			'build/js/util.min.js',
 			'build/js/device.min.js',
 			'build/js/screen-saver.min.js',
+			'build/js/nfc.min.js',
 			'build/js/sqlite.min.js',
 			'build/js/lang/*.min.js',
 			'build/js/abstracts/*.min.js',

--- a/grunt/uglify.js
+++ b/grunt/uglify.js
@@ -28,6 +28,16 @@ module.exports = {
 		src: 'build/bigi.js',
 		dest: 'build/bigi.min.js'
 	},
+	bitcoin: {
+		nonull: true,
+		options: {
+			mangle: {
+				reserved: ['BigInteger', 'ECPair', 'Point'],
+			},
+		},
+		src: 'build/bitcoin.js',
+		dest: 'build/bitcoin.min.js'
+	},
 	bs58: {
 		src: 'build/bs58.js',
 		dest: 'build/bs58.min.js'

--- a/html/app.html
+++ b/html/app.html
@@ -8,6 +8,7 @@
 	<a class="header-button offline"></a>
 	<a class="header-button more"></a>
 	<a class="header-button language"></a>
+	<a class="header-button qrcode"></a>
 </div>
 <div id="language-menu" class="menu"></div>
 <div id="more-menu" class="menu"></div>

--- a/images/qrcode.svg
+++ b/images/qrcode.svg
@@ -1,0 +1,122 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   width="324"
+   height="324"
+   viewBox="0 0 323.99999 323.99999"
+   id="svg3435"
+   version="1.1">
+  <defs
+     id="defs3437" />
+  <g
+     transform="matrix(1.059285,0,0,1.0592792,-157.10408,-307.75644)"
+     id="g3588">
+    <path
+       style="fill:#ccc;fill-opacity:1"
+       clip-path="none"
+       d="M 0.00390625,0.01953125 V 116.41016 H 116.39453 V 0.01953125 Z M 29.701172,29.294922 H 87.091797 V 86.683594 H 29.701172 Z"
+       transform="translate(172.41252,310.48901)"
+       id="rect3428" />
+    <rect
+       style="fill:#ccc;fill-opacity:1"
+       height="29.202143"
+       width="29.202143"
+       x="216.3418"
+       y="354.27362"
+       id="rect9-5" />
+  </g>
+  <g
+     id="g3588-2"
+     transform="matrix(1.059285,0,0,1.0592792,-5.0846347,-307.75966)">
+    <path
+       style="fill:#ccc;fill-opacity:1"
+       clip-path="none"
+       d="M 0.00390625,0.01953125 V 116.41016 H 116.39453 V 0.01953125 Z M 29.701172,29.294922 H 87.091797 V 86.683594 H 29.701172 Z"
+       transform="translate(172.41252,310.48901)"
+       id="rect3428-9" />
+    <rect
+       style="fill:#ccc;fill-opacity:1"
+       height="29.202143"
+       width="29.202143"
+       x="216.3418"
+       y="354.27362"
+       id="rect9-5-1" />
+  </g>
+  <g
+     id="g3588-2-2"
+     transform="matrix(1.059285,0,0,1.0592792,-158.63505,-152.20547)">
+    <path
+       style="fill:#ccc;fill-opacity:1"
+       clip-path="none"
+       d="M 0.00390625,0.01953125 V 116.41016 H 116.39453 V 0.01953125 Z M 29.701172,29.294922 H 87.091797 V 86.683594 H 29.701172 Z"
+       transform="translate(172.41252,310.48901)"
+       id="rect3428-9-7" />
+    <rect
+       style="fill:#ccc;fill-opacity:1"
+       height="29.202143"
+       width="29.202143"
+       x="216.3418"
+       y="354.27362"
+       id="rect9-5-1-0" />
+  </g>
+  <rect
+     style="stroke-width:1.05928206;fill:#ccc;fill-opacity:1"
+     id="rect49-0-0-0"
+     y="175.90616"
+     x="209.35866"
+     width="30.933392"
+     height="30.933222" />
+  <rect
+     style="stroke-width:1.05928206;fill:#ccc;fill-opacity:1"
+     id="rect49-0-0-0-9"
+     y="268.69543"
+     x="209.36726"
+     width="30.933392"
+     height="30.933222" />
+  <rect
+     style="stroke-width:1.05928206;fill:#ccc;fill-opacity:1"
+     id="rect49-0-0-0-9-3-6"
+     y="175.90616"
+     x="271.22543"
+     width="30.933392"
+     height="30.933222" />
+  <rect
+     style="stroke-width:1.05928206;fill:#ccc;fill-opacity:1"
+     id="rect49-0-0-0-9-3-6-0"
+     y="206.83939"
+     x="240.29205"
+     width="30.933392"
+     height="30.933222" />
+  <rect
+     style="stroke-width:1.05928206;fill:#ccc;fill-opacity:1"
+     id="rect49-0-0-0-9-3-62"
+     y="268.70584"
+     x="271.22543"
+     width="30.933392"
+     height="30.933222" />
+  <rect
+     style="stroke-width:1.05928206;fill:#ccc;fill-opacity:1"
+     id="rect49-0-0-0-9-6"
+     y="268.69543"
+     x="178.43387"
+     width="30.933392"
+     height="30.933222" />
+  <rect
+     style="stroke-width:1.05928206;fill:#ccc;fill-opacity:1"
+     id="rect49-0-0-0-9-3-6-0-8"
+     y="206.83939"
+     x="271.2254"
+     width="30.933392"
+     height="30.933222" />
+  <rect
+     style="stroke-width:1.05928206;fill:#ccc;fill-opacity:1"
+     id="rect49-0-0-0-9-3-62-7"
+     y="237.76221"
+     x="178.43387"
+     width="30.933392"
+     height="30.933222" />
+</svg>

--- a/js/config.js
+++ b/js/config.js
@@ -86,6 +86,7 @@ app.config = (function() {
 		},
 		paymentRequests: {
 			timeout: 5 * 60 * 1000,
+			saveDelay: 5000,
 		},
 		paymentHistory: {
 			list: {

--- a/js/nfc.js
+++ b/js/nfc.js
@@ -1,0 +1,143 @@
+var app = app || {};
+
+app.nfc = (function() {
+
+	'use strict';
+
+	return _.extend({}, {
+
+		/*
+			See:
+			https://github.com/chariotsolutions/phonegap-nfc#nfcreadermode
+		*/
+		startReading: function(options, onError) {
+
+			if (_.isFunction(options)) {
+				onError = options;
+				options = null;
+			}
+
+			options = options || {};
+
+			if (!onError) {
+				onError = _.noop;
+			}
+
+			var emit = _.bind(this.trigger, this);
+
+			var waiting = this.waitUntilEnabled(options, function(error) {
+				if (error) return onError(error);
+				// https://developer.android.com/reference/android/nfc/NfcAdapter#enableReaderMode(android.app.Activity,%20android.nfc.NfcAdapter.ReaderCallback,%20int,%20android.os.Bundle)
+				var flags = nfc.FLAG_READER_NFC_A | nfc.FLAG_READER_NO_PLATFORM_SOUNDS;
+				nfc.readerMode(flags, function onRead(evt) {
+					try {
+						var payload = evt && evt.ndefMessage && evt.ndefMessage[0] && evt.ndefMessage[0].payload || null;
+						var data = payload && nfc.bytesToString(payload).substr(1) || null;
+						if (data) {
+							emit('read', data);
+						}
+					} catch (error) {
+						app.log(error);
+					}
+				}, onError);
+			});
+
+			return {
+				cancel: function() {
+					waiting.cancel();
+				},
+			};
+		},
+
+		stopReading: function(cb) {
+
+			if (!cb) {
+				cb = _.noop;
+			}
+
+			this.checkEnabled(function(error, isEnabled) {
+				if (error) return cb(error);
+				if (!isEnabled) return cb();
+				nfc.disableReaderMode(function onSuccess() {
+					cb();
+				}, function onFailure(code) {
+					cb(new Error(code));
+				});
+			});
+		},
+
+		waitUntilEnabled: function(options, cb) {
+
+			if (_.isFunction(options)) {
+				cb = options;
+				options = null;
+			}
+
+			options = _.defaults(options || {}, {
+				checkDelay: 200,
+				timeout: 0,// Never
+			});
+
+			var checkEnabled = _.bind(this.checkEnabled, this);
+			var enabled = false;
+			var canceled = false;
+			var startTime = Date.now();
+			var checkTimeout;
+
+			async.until(function() { return enabled; }, function(next) {
+
+				checkEnabled(function(error, isEnabled, code) {
+
+					if (error) {
+						return next(error);
+					}
+
+					if (isEnabled) {
+						enabled = true;
+						return next();
+					}
+
+					if (code === 'NFC_DISABLED') {
+
+						var elapsedTime = Date.now() - startTime;
+
+						if (options.timeout && elapsedTime >= options.timeout) {
+							return next(new Error(code));
+						}
+
+						if (!canceled) {
+							checkTimeout = _.delay(next, options.checkDelay);
+						}
+
+					} else {
+						return next(new Error(code));
+					}
+				});
+
+			}, cb);
+
+			return {
+				cancel: function() {
+					clearTimeout(checkTimeout);
+					canceled = true;
+				},
+			};
+		},
+
+		checkEnabled: function(cb) {
+
+			if (typeof nfc === 'undefined') {
+				return _.defer(function() {
+					cb(null, false, 'NO_NFC');
+				});
+			}
+
+			nfc.enabled(function onSuccess() {
+				cb(null, true);
+			}, function onFailure(result) {
+				cb(null, false, result);
+			});
+		},
+	}, Backbone.Events);
+
+})();

--- a/js/payment-methods/bitcoin-testnet.js
+++ b/js/payment-methods/bitcoin-testnet.js
@@ -25,6 +25,7 @@ app.paymentMethods.bitcoinTestnet = (function() {
 			Network constants.
 		*/
 		network: {
+			messagePrefix: '\x18Bitcoin Signed Message:\n',
 			wif: 'ef',
 			p2pkh: '6f',
 			p2sh: 'c4',

--- a/js/payment-methods/bitcoin.js
+++ b/js/payment-methods/bitcoin.js
@@ -76,7 +76,7 @@ app.paymentMethods.bitcoin = (function() {
 				'settings.addressIndex.integer-required': 'Debe ser un entero',
 				'settings.addressIndex.greater-than-or-equal-zero': 'Debe ser mayor o igual que cero',
 				'settings.extendedPublicKey.label': 'Clave Pública Extendida',
-				'settings.extendedPublicKey.description': 'Usada para derivar una nueva direción cada vez que genere una solicitud de pago',
+				'settings.extendedPublicKey.description': 'Usada para derivar una nueva dirección cada vez que genere una solicitud de pago',
 				'incorrect-number-of-bytes': 'Número incorrecto de bytes',
 				'invalid-checksum': 'Suma de comprobación inválida',
 				'invalid-derivation-scheme': 'Esquema de derivación no válido',
@@ -108,10 +108,10 @@ app.paymentMethods.bitcoin = (function() {
 			{
 				name: 'extendedPublicKey',
 				label: function() {
-					return app.i18n.t(this.ref + '.settings.extendedPublicKey.label');
+					return app.i18n.t('bitcoin.settings.extendedPublicKey.label');
 				},
 				description: function() {
-					return app.i18n.t(this.ref + '.settings.extendedPublicKey.description');
+					return app.i18n.t('bitcoin.settings.extendedPublicKey.description');
 				},
 				type: 'text',
 				required: true,
@@ -130,10 +130,10 @@ app.paymentMethods.bitcoin = (function() {
 			{
 				name: 'addressIndex',
 				label: function() {
-					return app.i18n.t(this.ref + '.settings.addressIndex.label');
+					return app.i18n.t('bitcoin.settings.addressIndex.label');
 				},
 				description: function() {
-					return app.i18n.t(this.ref + '.settings.addressIndex.description');
+					return app.i18n.t('bitcoin.settings.addressIndex.description');
 				},
 				type: 'number',
 				required: true,
@@ -141,10 +141,10 @@ app.paymentMethods.bitcoin = (function() {
 				validate: function(value, data) {
 					value = parseInt(value);
 					if (_.isNaN(value)) {
-						throw new Error(app.i18n.t(this.ref + '.settings.addressIndex.integer-required'));
+						throw new Error(app.i18n.t('bitcoin.settings.addressIndex.integer-required'));
 					}
 					if (value < 0) {
-						throw new Error(app.i18n.t(this.ref + '.settings.addressIndex.greater-than-or-equal-zero'));
+						throw new Error(app.i18n.t('bitcoin.settings.addressIndex.greater-than-or-equal-zero'));
 					}
 				}
 			},

--- a/js/payment-methods/litecoin.js
+++ b/js/payment-methods/litecoin.js
@@ -26,7 +26,8 @@ app.paymentMethods.litecoin = (function() {
 			Network constants.
 		*/
 		network: {
-			wif: '80',
+			messagePrefix: '\x18Litecoin Signed Message:\n',
+			wif: 'b0',
 			p2pkh: '30',
 			p2sh: '32',
 			bech32: 'ltc',

--- a/js/payment-methods/litecoin.js
+++ b/js/payment-methods/litecoin.js
@@ -74,5 +74,57 @@ app.paymentMethods.litecoin = (function() {
 				],
 			},
 		},
+
+		settings: [
+			{
+				name: 'extendedPublicKey',
+				label: function() {
+					return app.i18n.t('litecoin.settings.extendedPublicKey.label');
+				},
+				description: function() {
+					return app.i18n.t('litecoin.settings.extendedPublicKey.description');
+				},
+				type: 'text',
+				required: true,
+				validateAsync: function(value, data, cb) {
+					this.decodeExtendedPublicKey(value, cb);
+				},
+				actions: [
+					{
+						name: 'camera',
+						fn: function(value, cb) {
+							app.device.scanQRCodeWithCamera(cb);
+						}
+					}
+				]
+			},
+			{
+				name: 'addressIndex',
+				label: function() {
+					return app.i18n.t('litecoin.settings.addressIndex.label');
+				},
+				description: function() {
+					return app.i18n.t('litecoin.settings.addressIndex.description');
+				},
+				type: 'number',
+				required: true,
+				default: '0',
+				validate: function(value, data) {
+					value = parseInt(value);
+					if (_.isNaN(value)) {
+						throw new Error(app.i18n.t('litecoin.settings.addressIndex.integer-required'));
+					}
+					if (value < 0) {
+						throw new Error(app.i18n.t('litecoin.settings.addressIndex.greater-than-or-equal-zero'));
+					}
+				}
+			},
+			{
+				name: 'derivationScheme',
+				type: 'text',
+				visible: false,
+				default: 'm/0/n',
+			}
+		],
 	});
 })();

--- a/js/router.js
+++ b/js/router.js
@@ -219,9 +219,6 @@ app.Router = (function() {
 				return false;
 			}
 
-			// Reset the method.
-			paymentRequest.set({ method: null });
-
 			app.mainView.renderView('ChoosePaymentMethod', { model: paymentRequest });
 		},
 

--- a/js/services/ct-api.js
+++ b/js/services/ct-api.js
@@ -210,6 +210,39 @@ app.services.ctApi = (function() {
 			}).catch(cb)
 		},
 
+		getFeeRate: function(network, cb) {
+
+			var uri = this.getUri('/api/v1/fee-rate', {
+				network: network,
+			});
+			$.get(uri).then(function(result) {
+				cb(null, result);
+			}).catch(cb)
+		},
+
+		getUnspentTxOutputs: function(network, addresses, cb) {
+
+			var uri = this.getUri('/api/v1/utxo', {
+				addresses: addresses.join(','),
+				network: network,
+			});
+			$.get(uri).then(function(result) {
+				cb(null, result);
+			}).catch(cb)
+		},
+
+		broadcastRawTx: function(network, rawTx, cb) {
+
+			var uri = this.getUri('/api/v1/raw-tx');
+			var data = {
+				network: network,
+				rawTx: rawTx,
+			};
+			$.post(uri, data).then(function(result) {
+				cb(null, result);
+			}).catch(cb)
+		},
+
 	}, Backbone.Events);
 
 	app.queues.onStart.push({

--- a/js/views/choose-payment-method.js
+++ b/js/views/choose-payment-method.js
@@ -17,6 +17,16 @@ app.views.ChoosePaymentMethod = (function() {
 			'click .cancel': 'cancel',
 		},
 
+		initialize: function() {
+
+			this.model.set({
+				data: {},
+				method: null,
+				rate: null,
+				uri: null,
+			});
+		},
+
 		serializeData: function() {
 
 			var data = {};

--- a/package-lock.json
+++ b/package-lock.json
@@ -252,6 +252,502 @@
         "js-tokens": "3.0.2"
       }
     },
+    "babel-core": {
+      "version": "6.26.3",
+      "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.26.3.tgz",
+      "integrity": "sha512-6jyFLuDmeidKmUEb3NM+/yawG0M2bDZ9Z1qbZP59cyHLz8kYGKYwpJP0UwUKKUiTRNvxfLesJnTedqczP7cTDA==",
+      "requires": {
+        "babel-code-frame": "6.26.0",
+        "babel-generator": "6.26.1",
+        "babel-helpers": "6.24.1",
+        "babel-messages": "6.23.0",
+        "babel-register": "6.26.0",
+        "babel-runtime": "6.26.0",
+        "babel-template": "6.26.0",
+        "babel-traverse": "6.26.0",
+        "babel-types": "6.26.0",
+        "babylon": "6.18.0",
+        "convert-source-map": "1.5.1",
+        "debug": "2.6.9",
+        "json5": "0.5.1",
+        "lodash": "4.17.10",
+        "minimatch": "3.0.4",
+        "path-is-absolute": "1.0.1",
+        "private": "0.1.8",
+        "slash": "1.0.0",
+        "source-map": "0.5.7"
+      },
+      "dependencies": {
+        "convert-source-map": {
+          "version": "1.5.1",
+          "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.5.1.tgz",
+          "integrity": "sha1-uCeAl7m8IpNl3lxiz1/K7YtVmeU="
+        }
+      }
+    },
+    "babel-generator": {
+      "version": "6.26.1",
+      "resolved": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.26.1.tgz",
+      "integrity": "sha512-HyfwY6ApZj7BYTcJURpM5tznulaBvyio7/0d4zFOeMPUmfxkCjHocCuoLa2SAGzBI8AREcH3eP3758F672DppA==",
+      "requires": {
+        "babel-messages": "6.23.0",
+        "babel-runtime": "6.26.0",
+        "babel-types": "6.26.0",
+        "detect-indent": "4.0.0",
+        "jsesc": "1.3.0",
+        "lodash": "4.17.10",
+        "source-map": "0.5.7",
+        "trim-right": "1.0.1"
+      }
+    },
+    "babel-helper-call-delegate": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-helper-call-delegate/-/babel-helper-call-delegate-6.24.1.tgz",
+      "integrity": "sha1-7Oaqzdx25Bw0YfiL/Fdb0Nqi340=",
+      "requires": {
+        "babel-helper-hoist-variables": "6.24.1",
+        "babel-runtime": "6.26.0",
+        "babel-traverse": "6.26.0",
+        "babel-types": "6.26.0"
+      }
+    },
+    "babel-helper-define-map": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-helper-define-map/-/babel-helper-define-map-6.26.0.tgz",
+      "integrity": "sha1-pfVtq0GiX5fstJjH66ypgZ+Vvl8=",
+      "requires": {
+        "babel-helper-function-name": "6.24.1",
+        "babel-runtime": "6.26.0",
+        "babel-types": "6.26.0",
+        "lodash": "4.17.10"
+      }
+    },
+    "babel-helper-function-name": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-6.24.1.tgz",
+      "integrity": "sha1-00dbjAPtmCQqJbSDUasYOZ01gKk=",
+      "requires": {
+        "babel-helper-get-function-arity": "6.24.1",
+        "babel-runtime": "6.26.0",
+        "babel-template": "6.26.0",
+        "babel-traverse": "6.26.0",
+        "babel-types": "6.26.0"
+      }
+    },
+    "babel-helper-get-function-arity": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.24.1.tgz",
+      "integrity": "sha1-j3eCqpNAfEHTqlCQj4mwMbG2hT0=",
+      "requires": {
+        "babel-runtime": "6.26.0",
+        "babel-types": "6.26.0"
+      }
+    },
+    "babel-helper-hoist-variables": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-helper-hoist-variables/-/babel-helper-hoist-variables-6.24.1.tgz",
+      "integrity": "sha1-HssnaJydJVE+rbyZFKc/VAi+enY=",
+      "requires": {
+        "babel-runtime": "6.26.0",
+        "babel-types": "6.26.0"
+      }
+    },
+    "babel-helper-optimise-call-expression": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-helper-optimise-call-expression/-/babel-helper-optimise-call-expression-6.24.1.tgz",
+      "integrity": "sha1-96E0J7qfc/j0+pk8VKl4gtEkQlc=",
+      "requires": {
+        "babel-runtime": "6.26.0",
+        "babel-types": "6.26.0"
+      }
+    },
+    "babel-helper-regex": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-helper-regex/-/babel-helper-regex-6.26.0.tgz",
+      "integrity": "sha1-MlxZ+QL4LyS3T6zu0DY5VPZJXnI=",
+      "requires": {
+        "babel-runtime": "6.26.0",
+        "babel-types": "6.26.0",
+        "lodash": "4.17.10"
+      }
+    },
+    "babel-helper-replace-supers": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-helper-replace-supers/-/babel-helper-replace-supers-6.24.1.tgz",
+      "integrity": "sha1-v22/5Dk40XNpohPKiov3S2qQqxo=",
+      "requires": {
+        "babel-helper-optimise-call-expression": "6.24.1",
+        "babel-messages": "6.23.0",
+        "babel-runtime": "6.26.0",
+        "babel-template": "6.26.0",
+        "babel-traverse": "6.26.0",
+        "babel-types": "6.26.0"
+      }
+    },
+    "babel-helpers": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-helpers/-/babel-helpers-6.24.1.tgz",
+      "integrity": "sha1-NHHenK7DiOXIUOWX5Yom3fN2ArI=",
+      "requires": {
+        "babel-runtime": "6.26.0",
+        "babel-template": "6.26.0"
+      }
+    },
+    "babel-messages": {
+      "version": "6.23.0",
+      "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
+      "integrity": "sha1-8830cDhYA1sqKVHG7F7fbGLyYw4=",
+      "requires": {
+        "babel-runtime": "6.26.0"
+      }
+    },
+    "babel-plugin-check-es2015-constants": {
+      "version": "6.22.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-check-es2015-constants/-/babel-plugin-check-es2015-constants-6.22.0.tgz",
+      "integrity": "sha1-NRV7EBQm/S/9PaP3XH0ekYNbv4o=",
+      "requires": {
+        "babel-runtime": "6.26.0"
+      }
+    },
+    "babel-plugin-transform-es2015-arrow-functions": {
+      "version": "6.22.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-arrow-functions/-/babel-plugin-transform-es2015-arrow-functions-6.22.0.tgz",
+      "integrity": "sha1-RSaSy3EdX3ncf4XkQM5BufJE0iE=",
+      "requires": {
+        "babel-runtime": "6.26.0"
+      }
+    },
+    "babel-plugin-transform-es2015-block-scoped-functions": {
+      "version": "6.22.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoped-functions/-/babel-plugin-transform-es2015-block-scoped-functions-6.22.0.tgz",
+      "integrity": "sha1-u8UbSflk1wy42OC5ToICRs46YUE=",
+      "requires": {
+        "babel-runtime": "6.26.0"
+      }
+    },
+    "babel-plugin-transform-es2015-block-scoping": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoping/-/babel-plugin-transform-es2015-block-scoping-6.26.0.tgz",
+      "integrity": "sha1-1w9SmcEwjQXBL0Y4E7CgnnOxiV8=",
+      "requires": {
+        "babel-runtime": "6.26.0",
+        "babel-template": "6.26.0",
+        "babel-traverse": "6.26.0",
+        "babel-types": "6.26.0",
+        "lodash": "4.17.10"
+      }
+    },
+    "babel-plugin-transform-es2015-classes": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-classes/-/babel-plugin-transform-es2015-classes-6.24.1.tgz",
+      "integrity": "sha1-WkxYpQyclGHlZLSyo7+ryXolhNs=",
+      "requires": {
+        "babel-helper-define-map": "6.26.0",
+        "babel-helper-function-name": "6.24.1",
+        "babel-helper-optimise-call-expression": "6.24.1",
+        "babel-helper-replace-supers": "6.24.1",
+        "babel-messages": "6.23.0",
+        "babel-runtime": "6.26.0",
+        "babel-template": "6.26.0",
+        "babel-traverse": "6.26.0",
+        "babel-types": "6.26.0"
+      }
+    },
+    "babel-plugin-transform-es2015-computed-properties": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-computed-properties/-/babel-plugin-transform-es2015-computed-properties-6.24.1.tgz",
+      "integrity": "sha1-b+Ko0WiV1WNPTNmZttNICjCBWbM=",
+      "requires": {
+        "babel-runtime": "6.26.0",
+        "babel-template": "6.26.0"
+      }
+    },
+    "babel-plugin-transform-es2015-destructuring": {
+      "version": "6.23.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-destructuring/-/babel-plugin-transform-es2015-destructuring-6.23.0.tgz",
+      "integrity": "sha1-mXux8auWf2gtKwh2/jWNYOdlxW0=",
+      "requires": {
+        "babel-runtime": "6.26.0"
+      }
+    },
+    "babel-plugin-transform-es2015-duplicate-keys": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-duplicate-keys/-/babel-plugin-transform-es2015-duplicate-keys-6.24.1.tgz",
+      "integrity": "sha1-c+s9MQypaePvnskcU3QabxV2Qj4=",
+      "requires": {
+        "babel-runtime": "6.26.0",
+        "babel-types": "6.26.0"
+      }
+    },
+    "babel-plugin-transform-es2015-for-of": {
+      "version": "6.23.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-for-of/-/babel-plugin-transform-es2015-for-of-6.23.0.tgz",
+      "integrity": "sha1-9HyVsrYT3x0+zC/bdXNiPHUkhpE=",
+      "requires": {
+        "babel-runtime": "6.26.0"
+      }
+    },
+    "babel-plugin-transform-es2015-function-name": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-function-name/-/babel-plugin-transform-es2015-function-name-6.24.1.tgz",
+      "integrity": "sha1-g0yJhTvDaxrw86TF26qU/Y6sqos=",
+      "requires": {
+        "babel-helper-function-name": "6.24.1",
+        "babel-runtime": "6.26.0",
+        "babel-types": "6.26.0"
+      }
+    },
+    "babel-plugin-transform-es2015-literals": {
+      "version": "6.22.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-literals/-/babel-plugin-transform-es2015-literals-6.22.0.tgz",
+      "integrity": "sha1-T1SgLWzWbPkVKAAZox0xklN3yi4=",
+      "requires": {
+        "babel-runtime": "6.26.0"
+      }
+    },
+    "babel-plugin-transform-es2015-modules-amd": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-amd/-/babel-plugin-transform-es2015-modules-amd-6.24.1.tgz",
+      "integrity": "sha1-Oz5UAXI5hC1tGcMBHEvS8AoA0VQ=",
+      "requires": {
+        "babel-plugin-transform-es2015-modules-commonjs": "6.26.2",
+        "babel-runtime": "6.26.0",
+        "babel-template": "6.26.0"
+      }
+    },
+    "babel-plugin-transform-es2015-modules-commonjs": {
+      "version": "6.26.2",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.26.2.tgz",
+      "integrity": "sha512-CV9ROOHEdrjcwhIaJNBGMBCodN+1cfkwtM1SbUHmvyy35KGT7fohbpOxkE2uLz1o6odKK2Ck/tz47z+VqQfi9Q==",
+      "requires": {
+        "babel-plugin-transform-strict-mode": "6.24.1",
+        "babel-runtime": "6.26.0",
+        "babel-template": "6.26.0",
+        "babel-types": "6.26.0"
+      }
+    },
+    "babel-plugin-transform-es2015-modules-systemjs": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-systemjs/-/babel-plugin-transform-es2015-modules-systemjs-6.24.1.tgz",
+      "integrity": "sha1-/4mhQrkRmpBhlfXxBuzzBdlAfSM=",
+      "requires": {
+        "babel-helper-hoist-variables": "6.24.1",
+        "babel-runtime": "6.26.0",
+        "babel-template": "6.26.0"
+      }
+    },
+    "babel-plugin-transform-es2015-modules-umd": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-umd/-/babel-plugin-transform-es2015-modules-umd-6.24.1.tgz",
+      "integrity": "sha1-rJl+YoXNGO1hdq22B9YCNErThGg=",
+      "requires": {
+        "babel-plugin-transform-es2015-modules-amd": "6.24.1",
+        "babel-runtime": "6.26.0",
+        "babel-template": "6.26.0"
+      }
+    },
+    "babel-plugin-transform-es2015-object-super": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-object-super/-/babel-plugin-transform-es2015-object-super-6.24.1.tgz",
+      "integrity": "sha1-JM72muIcuDp/hgPa0CH1cusnj40=",
+      "requires": {
+        "babel-helper-replace-supers": "6.24.1",
+        "babel-runtime": "6.26.0"
+      }
+    },
+    "babel-plugin-transform-es2015-parameters": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-parameters/-/babel-plugin-transform-es2015-parameters-6.24.1.tgz",
+      "integrity": "sha1-V6w1GrScrxSpfNE7CfZv3wpiXys=",
+      "requires": {
+        "babel-helper-call-delegate": "6.24.1",
+        "babel-helper-get-function-arity": "6.24.1",
+        "babel-runtime": "6.26.0",
+        "babel-template": "6.26.0",
+        "babel-traverse": "6.26.0",
+        "babel-types": "6.26.0"
+      }
+    },
+    "babel-plugin-transform-es2015-shorthand-properties": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-shorthand-properties/-/babel-plugin-transform-es2015-shorthand-properties-6.24.1.tgz",
+      "integrity": "sha1-JPh11nIch2YbvZmkYi5R8U3jiqA=",
+      "requires": {
+        "babel-runtime": "6.26.0",
+        "babel-types": "6.26.0"
+      }
+    },
+    "babel-plugin-transform-es2015-spread": {
+      "version": "6.22.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-spread/-/babel-plugin-transform-es2015-spread-6.22.0.tgz",
+      "integrity": "sha1-1taKmfia7cRTbIGlQujdnxdG+NE=",
+      "requires": {
+        "babel-runtime": "6.26.0"
+      }
+    },
+    "babel-plugin-transform-es2015-sticky-regex": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-sticky-regex/-/babel-plugin-transform-es2015-sticky-regex-6.24.1.tgz",
+      "integrity": "sha1-AMHNsaynERLN8M9hJsLta0V8zbw=",
+      "requires": {
+        "babel-helper-regex": "6.26.0",
+        "babel-runtime": "6.26.0",
+        "babel-types": "6.26.0"
+      }
+    },
+    "babel-plugin-transform-es2015-template-literals": {
+      "version": "6.22.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-template-literals/-/babel-plugin-transform-es2015-template-literals-6.22.0.tgz",
+      "integrity": "sha1-qEs0UPfp+PH2g51taH2oS7EjbY0=",
+      "requires": {
+        "babel-runtime": "6.26.0"
+      }
+    },
+    "babel-plugin-transform-es2015-typeof-symbol": {
+      "version": "6.23.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-typeof-symbol/-/babel-plugin-transform-es2015-typeof-symbol-6.23.0.tgz",
+      "integrity": "sha1-3sCfHN3/lLUqxz1QXITfWdzOs3I=",
+      "requires": {
+        "babel-runtime": "6.26.0"
+      }
+    },
+    "babel-plugin-transform-es2015-unicode-regex": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-unicode-regex/-/babel-plugin-transform-es2015-unicode-regex-6.24.1.tgz",
+      "integrity": "sha1-04sS9C6nMj9yk4fxinxa4frrNek=",
+      "requires": {
+        "babel-helper-regex": "6.26.0",
+        "babel-runtime": "6.26.0",
+        "regexpu-core": "2.0.0"
+      }
+    },
+    "babel-plugin-transform-regenerator": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-regenerator/-/babel-plugin-transform-regenerator-6.26.0.tgz",
+      "integrity": "sha1-4HA2lvveJ/Cj78rPi03KL3s6jy8=",
+      "requires": {
+        "regenerator-transform": "0.10.1"
+      }
+    },
+    "babel-plugin-transform-strict-mode": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-strict-mode/-/babel-plugin-transform-strict-mode-6.24.1.tgz",
+      "integrity": "sha1-1fr3qleKZbvlkc9e2uBKDGcCB1g=",
+      "requires": {
+        "babel-runtime": "6.26.0",
+        "babel-types": "6.26.0"
+      }
+    },
+    "babel-preset-es2015": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-preset-es2015/-/babel-preset-es2015-6.24.1.tgz",
+      "integrity": "sha1-1EBQ1rwsn+6nAqrzjXJ6AhBTiTk=",
+      "requires": {
+        "babel-plugin-check-es2015-constants": "6.22.0",
+        "babel-plugin-transform-es2015-arrow-functions": "6.22.0",
+        "babel-plugin-transform-es2015-block-scoped-functions": "6.22.0",
+        "babel-plugin-transform-es2015-block-scoping": "6.26.0",
+        "babel-plugin-transform-es2015-classes": "6.24.1",
+        "babel-plugin-transform-es2015-computed-properties": "6.24.1",
+        "babel-plugin-transform-es2015-destructuring": "6.23.0",
+        "babel-plugin-transform-es2015-duplicate-keys": "6.24.1",
+        "babel-plugin-transform-es2015-for-of": "6.23.0",
+        "babel-plugin-transform-es2015-function-name": "6.24.1",
+        "babel-plugin-transform-es2015-literals": "6.22.0",
+        "babel-plugin-transform-es2015-modules-amd": "6.24.1",
+        "babel-plugin-transform-es2015-modules-commonjs": "6.26.2",
+        "babel-plugin-transform-es2015-modules-systemjs": "6.24.1",
+        "babel-plugin-transform-es2015-modules-umd": "6.24.1",
+        "babel-plugin-transform-es2015-object-super": "6.24.1",
+        "babel-plugin-transform-es2015-parameters": "6.24.1",
+        "babel-plugin-transform-es2015-shorthand-properties": "6.24.1",
+        "babel-plugin-transform-es2015-spread": "6.22.0",
+        "babel-plugin-transform-es2015-sticky-regex": "6.24.1",
+        "babel-plugin-transform-es2015-template-literals": "6.22.0",
+        "babel-plugin-transform-es2015-typeof-symbol": "6.23.0",
+        "babel-plugin-transform-es2015-unicode-regex": "6.24.1",
+        "babel-plugin-transform-regenerator": "6.26.0"
+      }
+    },
+    "babel-register": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-register/-/babel-register-6.26.0.tgz",
+      "integrity": "sha1-btAhFz4vy0htestFxgCahW9kcHE=",
+      "requires": {
+        "babel-core": "6.26.3",
+        "babel-runtime": "6.26.0",
+        "core-js": "2.5.7",
+        "home-or-tmp": "2.0.0",
+        "lodash": "4.17.10",
+        "mkdirp": "0.5.1",
+        "source-map-support": "0.4.18"
+      }
+    },
+    "babel-runtime": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
+      "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
+      "requires": {
+        "core-js": "2.5.7",
+        "regenerator-runtime": "0.11.1"
+      }
+    },
+    "babel-template": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.26.0.tgz",
+      "integrity": "sha1-3gPi0WOWsGn0bdn/+FIfsaDjXgI=",
+      "requires": {
+        "babel-runtime": "6.26.0",
+        "babel-traverse": "6.26.0",
+        "babel-types": "6.26.0",
+        "babylon": "6.18.0",
+        "lodash": "4.17.10"
+      }
+    },
+    "babel-traverse": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.26.0.tgz",
+      "integrity": "sha1-RqnL1+3MYsjlwGTi0tjQ9ANXZu4=",
+      "requires": {
+        "babel-code-frame": "6.26.0",
+        "babel-messages": "6.23.0",
+        "babel-runtime": "6.26.0",
+        "babel-types": "6.26.0",
+        "babylon": "6.18.0",
+        "debug": "2.6.9",
+        "globals": "9.18.0",
+        "invariant": "2.2.4",
+        "lodash": "4.17.10"
+      },
+      "dependencies": {
+        "globals": {
+          "version": "9.18.0",
+          "resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
+          "integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ=="
+        }
+      }
+    },
+    "babel-types": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.26.0.tgz",
+      "integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
+      "requires": {
+        "babel-runtime": "6.26.0",
+        "esutils": "2.0.2",
+        "lodash": "4.17.10",
+        "to-fast-properties": "1.0.3"
+      }
+    },
+    "babelify": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/babelify/-/babelify-8.0.0.tgz",
+      "integrity": "sha512-xVr63fKEvMWUrrIbqlHYsMcc5Zdw4FSVesAHgkgajyCE1W8gbm9rbMakqavhxKvikGYMhEcqxTwB/gQmQ6lBtw=="
+    },
+    "babylon": {
+      "version": "6.18.0",
+      "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
+      "integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ=="
+    },
     "backbone": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/backbone/-/backbone-1.3.3.tgz",
@@ -317,6 +813,59 @@
       "version": "7.2.1",
       "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-7.2.1.tgz",
       "integrity": "sha512-S4XzBk5sMB+Rcb/LNcpzXr57VRTxgAvaAEDAl1AwRx27j00hT84O6OkteE7u8UB3NuaaygCRrEpqox4uDOrbdQ=="
+    },
+    "bindings": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.3.0.tgz",
+      "integrity": "sha512-DpLh5EzMR2kzvX1KIlVC0VkC3iZtHKTgdtZ0a3pglBZdaQFjt5S9g9xd1lE+YvXyfd6mtCeRnrUfOLYiTMlNSw=="
+    },
+    "bip32": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/bip32/-/bip32-1.0.2.tgz",
+      "integrity": "sha512-kedLYj8yvYzND+EfzeoMSlGiN7ImiRBF/MClJSZPkMfcU+OQO7ZpL5L/Yg+TunebBZIHhunstiQF//KLKSF5rg==",
+      "requires": {
+        "bs58check": "2.1.2",
+        "create-hash": "1.2.0",
+        "create-hmac": "1.1.7",
+        "tiny-secp256k1": "1.0.0",
+        "typeforce": "1.12.0",
+        "wif": "2.0.6"
+      }
+    },
+    "bip66": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/bip66/-/bip66-1.1.5.tgz",
+      "integrity": "sha1-AfqHSHhcpwlV1QESF9GzE5lpyiI=",
+      "requires": {
+        "safe-buffer": "5.1.2"
+      }
+    },
+    "bitcoin-ops": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/bitcoin-ops/-/bitcoin-ops-1.4.1.tgz",
+      "integrity": "sha512-pef6gxZFztEhaE9RY9HmWVmiIHqCb2OyS4HPKkpc6CIiiOa3Qmuoylxc5P2EkU3w+5eTSifI9SEZC88idAIGow=="
+    },
+    "bitcoinjs-lib": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/bitcoinjs-lib/-/bitcoinjs-lib-4.0.1.tgz",
+      "integrity": "sha512-weum3uRYWxGhAvRk+2Ch7Z3x5tKBfeuzVyoGdP1CMrGJ5Nw6plj1GVA3A+RejLDii7UM7OxgOfXgPZhLmI7+vQ==",
+      "requires": {
+        "bech32": "1.1.3",
+        "bip32": "1.0.2",
+        "bip66": "1.1.5",
+        "bitcoin-ops": "1.4.1",
+        "bs58check": "2.1.2",
+        "create-hash": "1.2.0",
+        "create-hmac": "1.1.7",
+        "merkle-lib": "2.0.10",
+        "pushdata-bitcoin": "1.0.1",
+        "randombytes": "2.0.6",
+        "safe-buffer": "5.1.2",
+        "tiny-secp256k1": "1.0.0",
+        "typeforce": "1.12.0",
+        "varuint-bitcoin": "1.1.0",
+        "wif": "2.0.6"
+      }
     },
     "bn.js": {
       "version": "4.11.8",
@@ -519,6 +1068,16 @@
       "integrity": "sha1-vhYedsNU9veIrkBx9j806MTwpCo=",
       "requires": {
         "base-x": "3.0.4"
+      }
+    },
+    "bs58check": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/bs58check/-/bs58check-2.1.2.tgz",
+      "integrity": "sha512-0TS1jicxdU09dwJMNZtVAfzPi6Q6QeN0pM1Fkzrjn+XYHvzMKPU3pHVpva+769iNVSfIYWf7LJ6WR+BuuMf8cA==",
+      "requires": {
+        "bs58": "4.0.1",
+        "create-hash": "1.2.0",
+        "safe-buffer": "5.1.2"
       }
     },
     "buffer": {
@@ -1762,6 +2321,11 @@
       "resolved": "https://registry.npmjs.org/cordova-sqlite-storage-dependencies/-/cordova-sqlite-storage-dependencies-1.2.0.tgz",
       "integrity": "sha512-lJl5uJFrCWrCYYGhpSEXe6sepjgOOzbeh8fFur3LqaSRvx+xFNYtfMYumE0+xqZwSmPODzex+y6I7ixwcBn73Q=="
     },
+    "core-js": {
+      "version": "2.5.7",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.7.tgz",
+      "integrity": "sha512-RszJCAxg/PP6uzXVXL6BsxSXx/B05oJAQ2vkJRjyjrEcNVycaqOmNb5OTxZPE3xa5gwZduqza6L9JOCenh/Ecw=="
+    },
     "core-util-is": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
@@ -1984,6 +2548,14 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
       "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA="
+    },
+    "detect-indent": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-4.0.0.tgz",
+      "integrity": "sha1-920GQ1LN9Docts5hnE7jqUdd4gg=",
+      "requires": {
+        "repeating": "2.0.1"
+      }
     },
     "detective": {
       "version": "5.1.0",
@@ -3126,6 +3698,15 @@
         "minimalistic-crypto-utils": "1.0.1"
       }
     },
+    "home-or-tmp": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-2.0.0.tgz",
+      "integrity": "sha1-42w/LSyufXRqhX440Y1fMqeILbg=",
+      "requires": {
+        "os-homedir": "1.0.2",
+        "os-tmpdir": "1.0.2"
+      }
+    },
     "hooker": {
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/hooker/-/hooker-0.2.3.tgz",
@@ -3337,6 +3918,14 @@
         "xtend": "4.0.1"
       }
     },
+    "invariant": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
+      "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
+      "requires": {
+        "loose-envify": "1.4.0"
+      }
+    },
     "invert-kv": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
@@ -3481,6 +4070,11 @@
         "esprima": "2.7.3"
       }
     },
+    "jsesc": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-1.3.0.tgz",
+      "integrity": "sha1-RsP+yMGJKxKwgz25vHYiF226s0s="
+    },
     "json-schema-traverse": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
@@ -3498,6 +4092,11 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
       "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE="
+    },
+    "json5": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
+      "integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE="
     },
     "jsonify": {
       "version": "0.0.0",
@@ -3660,6 +4259,14 @@
       "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
       "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc="
     },
+    "loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "requires": {
+        "js-tokens": "3.0.2"
+      }
+    },
     "loud-rejection": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.6.0.tgz",
@@ -3737,6 +4344,11 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
       "integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E="
+    },
+    "merkle-lib": {
+      "version": "2.0.10",
+      "resolved": "https://registry.npmjs.org/merkle-lib/-/merkle-lib-2.0.10.tgz",
+      "integrity": "sha1-grjbrnXieneFOItz+ddyXQ9vMyY="
     },
     "methods": {
       "version": "1.1.2",
@@ -3914,6 +4526,11 @@
       "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
       "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s="
     },
+    "nan": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.10.0.tgz",
+      "integrity": "sha512-bAdJv7fBLhWC+/Bls0Oza+mvTaNQtP+1RyhhhvD95pgUJz6XM5IzgmxOkItJ9tkoCiplvAnXI1tNmmUD/eScyA=="
+    },
     "nanoid": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-1.0.4.tgz",
@@ -4056,6 +4673,11 @@
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/os-browserify/-/os-browserify-0.3.0.tgz",
       "integrity": "sha1-hUNzx/XCMVkU/Jv8a9gjj92h7Cc="
+    },
+    "os-homedir": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+      "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M="
     },
     "os-locale": {
       "version": "2.1.0",
@@ -4216,6 +4838,11 @@
       "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
       "integrity": "sha1-elfrVQpng/kRUzH89GY9XI4AelA="
     },
+    "phonegap-nfc": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/phonegap-nfc/-/phonegap-nfc-1.0.3.tgz",
+      "integrity": "sha512-z2Usir2k8lNuvx6ITq8Xklu1HblzXkyfANc6Vx/liDGB1Az1lyu39qfEuRhQfjX2zSR2tcvsJ5z8yZQZaQ+MWw=="
+    },
     "phonegap-plugin-barcodescanner": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/phonegap-plugin-barcodescanner/-/phonegap-plugin-barcodescanner-8.0.0.tgz",
@@ -4325,6 +4952,11 @@
         "ultron": "1.1.1"
       }
     },
+    "private": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/private/-/private-0.1.8.tgz",
+      "integrity": "sha512-VvivMrbvd2nKkiG38qjULzlc+4Vx4wm/whI9pQD35YrARNnhxeiRktSOhSukRLFNlzg6Br/cJPet5J/u19r/mg=="
+    },
     "process": {
       "version": "0.11.10",
       "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
@@ -4404,6 +5036,14 @@
           "resolved": "https://registry.npmjs.org/mime/-/mime-2.3.1.tgz",
           "integrity": "sha512-OEUllcVoydBHGN1z84yfQDimn58pZNNNXgZlHXSboxMlFvgI6MXSWpWKpFRra7H1HxpVhHTkrghfRW49k6yjeg=="
         }
+      }
+    },
+    "pushdata-bitcoin": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/pushdata-bitcoin/-/pushdata-bitcoin-1.0.1.tgz",
+      "integrity": "sha1-FZMdPNlnreUiBvUjqnMxrvfUOvc=",
+      "requires": {
+        "bitcoin-ops": "1.4.1"
       }
     },
     "qrcode": {
@@ -4667,6 +5307,26 @@
         "strip-indent": "1.0.1"
       }
     },
+    "regenerate": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.4.0.tgz",
+      "integrity": "sha512-1G6jJVDWrt0rK99kBjvEtziZNCICAuvIPkSiUFIQxVP06RCVpq3dmDo2oi6ABpYaDYaTRr67BEhL8r1wgEZZKg=="
+    },
+    "regenerator-runtime": {
+      "version": "0.11.1",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
+      "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg=="
+    },
+    "regenerator-transform": {
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.10.1.tgz",
+      "integrity": "sha512-PJepbvDbuK1xgIgnau7Y90cwaAmO/LCLMI2mPvaXq2heGMR3aWW5/BQvYrhJ8jgmQjXewXvBjzfqKcVOmhjZ6Q==",
+      "requires": {
+        "babel-runtime": "6.26.0",
+        "babel-types": "6.26.0",
+        "private": "0.1.8"
+      }
+    },
     "regexp.prototype.flags": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.2.0.tgz",
@@ -4679,6 +5339,36 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-2.0.0.tgz",
       "integrity": "sha512-g2FAVtR8Uh8GO1Nv5wpxW7VFVwHcCEr4wyA8/MHiRkO8uHoR5ntAA8Uq3P1vvMTX/BeQiRVSpDGLd+Wn5HNOTA=="
+    },
+    "regexpu-core": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-2.0.0.tgz",
+      "integrity": "sha1-SdA4g3uNz4v6W5pCE5k45uoq4kA=",
+      "requires": {
+        "regenerate": "1.4.0",
+        "regjsgen": "0.2.0",
+        "regjsparser": "0.1.5"
+      }
+    },
+    "regjsgen": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.2.0.tgz",
+      "integrity": "sha1-bAFq3qxVT3WCP+N6wFuS1aTtsfc="
+    },
+    "regjsparser": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.1.5.tgz",
+      "integrity": "sha1-fuj4Tcb6eS0/0K4ijSS9lJ6tIFw=",
+      "requires": {
+        "jsesc": "0.5.0"
+      },
+      "dependencies": {
+        "jsesc": {
+          "version": "0.5.0",
+          "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
+          "integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0="
+        }
+      }
     },
     "repeat-string": {
       "version": "1.6.1",
@@ -4942,6 +5632,11 @@
       "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.0.tgz",
       "integrity": "sha1-c0TLuLbib7J9ZrL8hvn21Zl1IcY="
     },
+    "slash": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
+      "integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU="
+    },
     "slice-ansi": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-1.0.0.tgz",
@@ -4954,6 +5649,14 @@
       "version": "0.5.7",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
       "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
+    },
+    "source-map-support": {
+      "version": "0.4.18",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.18.tgz",
+      "integrity": "sha512-try0/JqxPLF9nOjvSta7tVondkP5dwgyLDjVoyMDlmjugT2lRZ1OfsrYTkCd2hkDnJTKRbO/Rl3orm8vlsUzbA==",
+      "requires": {
+        "source-map": "0.5.7"
+      }
     },
     "spdx-correct": {
       "version": "3.0.0",
@@ -5228,6 +5931,18 @@
         "process": "0.11.10"
       }
     },
+    "tiny-secp256k1": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/tiny-secp256k1/-/tiny-secp256k1-1.0.0.tgz",
+      "integrity": "sha512-Wd4YPIQUtNmFoszG9f4PAkpCTurF5deVrbS1KuIZ9LTo9AHmXwbl1iNTrDqT3/xI62TRi0OcVs6eXk+8OcDziQ==",
+      "requires": {
+        "bindings": "1.3.0",
+        "bn.js": "4.11.8",
+        "create-hmac": "1.1.7",
+        "elliptic": "6.4.0",
+        "nan": "2.10.0"
+      }
+    },
     "tmp": {
       "version": "0.0.33",
       "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
@@ -5241,10 +5956,20 @@
       "resolved": "https://registry.npmjs.org/to-arraybuffer/-/to-arraybuffer-1.0.1.tgz",
       "integrity": "sha1-fSKbH8xjfkZsoIEYCDanqr/4P0M="
     },
+    "to-fast-properties": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
+      "integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc="
+    },
     "trim-newlines": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz",
       "integrity": "sha1-WIeWa7WCpFA6QetST301ARgVphM="
+    },
+    "trim-right": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
+      "integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM="
     },
     "tty-browserify": {
       "version": "0.0.1",
@@ -5285,6 +6010,11 @@
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
+    },
+    "typeforce": {
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/typeforce/-/typeforce-1.12.0.tgz",
+      "integrity": "sha512-fvnkvueAOFLhtAqDgIA/wMP21SMwS/NQESFKZuwVrj5m/Ew6eK2S0z0iB++cwtROPWDOhaT6OUfla8UwMw4Adg=="
     },
     "uglify-js": {
       "version": "3.4.7",
@@ -5416,6 +6146,14 @@
         "spdx-expression-parse": "3.0.0"
       }
     },
+    "varuint-bitcoin": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/varuint-bitcoin/-/varuint-bitcoin-1.1.0.tgz",
+      "integrity": "sha512-jCEPG+COU/1Rp84neKTyDJQr478/hAfVp5xxYn09QEH0yBjbmPeMfuuQIrp+BUD83hybtYZKhr5elV3bvdV1bA==",
+      "requires": {
+        "safe-buffer": "5.1.2"
+      }
+    },
     "vary": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
@@ -5438,6 +6176,14 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
       "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho="
+    },
+    "wif": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/wif/-/wif-2.0.6.tgz",
+      "integrity": "sha1-CNP1IFbGZnkplyb63g1DKudLRwQ=",
+      "requires": {
+        "bs58check": "2.1.2"
+      }
     },
     "window-or-global": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -40,12 +40,16 @@
   "dependencies": {
     "android-versions": "1.3.0",
     "async": "2.6.1",
+    "babel-core": "6.26.3",
+    "babel-preset-es2015": "6.24.1",
+    "babelify": "8.0.0",
     "backbone": "1.3.3",
     "backbone.localstorage": "2.0.2",
     "base-x": "3.0.4",
     "bech32": "1.1.3",
     "bigi": "1.4.2",
     "bignumber.js": "7.2.1",
+    "bitcoinjs-lib": "4.0.1",
     "browserify": "16.2.2",
     "bs58": "4.0.1",
     "chai": "4.1.2",
@@ -58,6 +62,7 @@
     "cordova-plugin-network-information": "2.0.1",
     "cordova-plugin-whitelist": "1.3.3",
     "cordova-sqlite-storage": "2.3.3",
+    "core-js": "2.5.7",
     "ecurve": "1.0.6",
     "express": "4.16.3",
     "grunt": "1.0.3",
@@ -78,6 +83,7 @@
     "mocha": "5.2.0",
     "moment": "2.22.2",
     "open-sans-fontface": "https://github.com/samotari/open-sans/archive/1.4.2.tar.gz",
+    "phonegap-nfc": "1.0.3",
     "phonegap-plugin-barcodescanner": "8.0.0",
     "primus": "7.2.2",
     "puppeteer": "1.7.0",
@@ -100,7 +106,8 @@
       "cordova-plugin-inappbrowser": {},
       "cordova-plugin-network-information": {},
       "cordova-plugin-ionic-keyboard": {},
-      "cordova-plugin-nativeaudio": {}
+      "cordova-plugin-nativeaudio": {},
+      "phonegap-nfc": {}
     }
   }
 }


### PR DESCRIPTION
Fixed:
* [x] After activating the camera to scan a paper wallet, cancel the camera by going back. Now an error is displayed because the app is trying to pay from a paper wallet that is an empty string.
* [x] NFC scanning wallet throws some error, preventing the payment from being accepted
* [x] When NFC is disabled (or unavailable) on the device, there are thrown errors. For example, the back/cancel buttons don't work anymore.
* [x] "Invalid network version" when trying to scan + pay with litecoin paper wallet (WIF)

Requires [this pull-request](https://github.com/samotari/ct-api-server/pull/57) on ct-api-server

