### PR TITLE
fdroid build script adds missing supporting files

### DIFF
--- a/scripts/fdroid-release.sh
+++ b/scripts/fdroid-release.sh
@@ -80,7 +80,9 @@ git add -f 	$PLATFORMS/android/app \
 			$PLATFORMS/android/build.gradle \
 			$PLATFORMS/android/project.properties \
 			$PLATFORMS/android/settings.gradle \
-			$PLATFORMS/android/wrapper.gradle
+			$PLATFORMS/android/wrapper.gradle \
+			$PLATFORMS/android/phonegap-plugin-barcodescanner/cryptoterminal-barcodescanner.gradle \
+			$PLATFORMS/android/cordova-android-support-gradle-release/cryptoterminal-cordova-android-support-gradle-release.gradle
 
 # commit
 git commit -m "fdroid release $VERSION"


### PR DESCRIPTION
This is the pull request which adds some files that are missing for a successful gradle build, that is required for a fdroid.

After including this PR, re-run `./scripts/fdroid-release.sh` to update the fdroid branch.